### PR TITLE
Fixes font issue with paragraphs

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,7 @@
 @font-face {
   font-family: 'daniel';
   src: url("daniel.ttf");
-};
+}
 
 @font-face {
   font-family: 'comfortaaBold';
@@ -11,7 +11,7 @@
 h1 {
   font-family: 'daniel';
   color: hotpink;
-};
+}
 
 p {
   font-family: 'daniel';

--- a/styles.css
+++ b/styles.css
@@ -13,11 +13,6 @@ h1 {
   color: hotpink;
 };
 
-@font-face {
-  font-family: 'daniel';
-  src: url("daniel.ttf");
-};
-
 p {
   font-family: 'daniel';
 }


### PR DESCRIPTION
There were two problems

1. You were writing @font-face for the same font twice.  This was probably being ignored.  I removed it anyway just for the sake of cleanliness
2. You were writing `;` at the end of rules.  Those were being interpreted as the beginnings of the next rule instead, meaning the rule that you thought was `p {}` was actually `;p {}`, which didn't match the tag and therefore never applied.

[I made a video tutorial explaining how to debug this](https://www.youtube.com/watch?v=y1LV8irDHv4), how to look bad while debugging this, how to use the debugger in the browser, how to fork a repo, and how to PR the fix back.

Probably wait a half hour or so before watching the tutorial, so that YouTube has time to encode it to a high enough resolution that any of the text is readable.

Have a good `#include <whatever/fucking/time/it/is/there>`